### PR TITLE
hotfix-screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,108 +10,112 @@
 <body>
     <!-- 时钟面 -->
     <div id="face">
-        <svg id="canvas">
-            <!-- svg写在这一部分 -->
-            <circle id="outline" cx=540px cy=360px r=345px stroke="black" stroke-width="3px" fill="transparent">
-            </circle>
-            <circle id="inline" cx=540px cy=360px r=320px stroke="black" stroke-width="2px" fill="transparent"></circle>
-            <polygon id="minPointer" points="538,80 542,80 546,360 534,360" fill=black></polygon>
-            <polygon id="houPointer" points="536,150 544,150 548,360 532,360" fill=green></polygon>
-            <circle id="secCenter" cx=540 cy=360 r=12 style="fill:red"></circle>
-            <polygon id="secPointer" points="538,70 542,70 544,360 536,360" fill=red></polygon>
-        </svg>
+        <div id="svgclock">
+            <svg id="canvas">
+                <!-- svg写在这一部分 -->
+                <circle id="outline" cx=540px cy=360px r=345px stroke="black" stroke-width="3px" fill="transparent">
+                </circle>
+                <circle id="inline" cx=540px cy=360px r=320px stroke="black" stroke-width="2px" fill="transparent"></circle>
+                <polygon id="minPointer" points="538,80 542,80 546,360 534,360" fill=black></polygon>
+                <polygon id="houPointer" points="536,150 544,150 548,360 532,360" fill=green></polygon>
+                <circle id="secCenter" cx=540 cy=360 r=12 style="fill:red"></circle>
+                <polygon id="secPointer" points="538,70 542,70 544,360 536,360" fill=red></polygon>
+            </svg>
+        </div>
         <!-- 以下部分需要css样式 -->
-        <div id="funcbackground"></div>
-        <!-- 数字时钟 -->
-        <div id="digitalCss">
-            <div class="hourCss">
-                <p class="digitalCss_label">  Hours</p>
-            </div>
-            <div class="minuteCss">
-                <p class="digitalCss_label">Minutes</p>
-            </div>
-            <div class="secondCss">
-                <p class="digitalCss_label">Seconds</p>
-            </div>
-        </div>
-        <div id="digital">00:00:00</div>
-        <!-- 闹钟 -->
-        <div id="alarmTitle">
-            <p class="labelTitle">
-                闹钟<br>alarm
-                <div class="circle"></div>
-            </p>    
-        </div>
-        <div id="alarm">
-            <form id="alarmForm">
-                <input type="time" id="alarmTime" value="12:12">
-                <div class="alarmbuttonCss">
-                    <input type="radio" name="alarm" value="on" onchange="alarmon()" id="alarmonCss">
-                    <label for="alarmonCss" class="onCss">
-                        <p>ON</p>
-                    </label>
-                    <input type="radio" name="alarm" value="off" onchange="alarmoff()" checked="true" id="alarmoffCss">
-                    <label for="alarmoffCss" class="offCss">
-                        <p>OFF</p>
-                    </label>
+        <div id="clockfunction">
+            <div id="funcbackground"></div>
+            <!-- 数字时钟 -->
+            <div id="digitalCss">
+                <div class="hourCss">
+                    <p class="digitalCss_label">  Hours</p>
                 </div>
-            </form>
-        </div>
-        <!-- 秒表 -->
-        <div id="stopwatchTitle">
-            <p class="labelTitle">
-                秒表<br>stopwatch
-                <div class="circle"></div>
-            </p>    
-        </div>
-        <div id="se">
-            <form id="seForm">
-                <div id="stopwatchtimeCss">
-                    <div id="seDigital">00:00.00</div>
-                </div>              
-                <button type="button" onclick="resetSe()" name="reset" class="buttonCss1">重置</button>
-                <button type="button" onclick="started()" id="start" class="buttonCss">开始</button>
-                <button type="button" onclick="paused()" id="pause" style="display: none;" class="buttonCss">暂停</button>
-            </form>
-        </div>
-        <!-- 计时器 -->
-        <div id="timerTitle">
-            <p class="labelTitle">
-                计时器<br>timer
-                <div class="circle"></div>
-            </p>    
-        </div>
-        <div id="counter">
-            <form id="couterForm">
-                <div id="counterIn">
-                    <input type="number" id="counterH" min="0" max="23" value="0">
-                    <input type="number" id="counterM" min="0" max="59" value="0">
-                    <input type="number" id="counterS" min="0" max="59" value="0">
+                <div class="minuteCss">
+                    <p class="digitalCss_label">Minutes</p>
                 </div>
-                <div id="counterOut" style="display: none;">
-                    00:00:00
+                <div class="secondCss">
+                    <p class="digitalCss_label">Seconds</p>
                 </div>
-                <br>
-                <button type="button" onclick="resetCounter()" name="reset" class="buttonCss1">重置</button>
-                <button type="button" onclick="startedCounter()" id="startC" class="buttonCss">开始</button>
-                <button type="button" onclick="pausedCounter()" id="pauseC" style="display: none;" class="buttonCss2">暂停</button>
-            </form>
-        </div>
-        <!-- 参数调整时间 -->
-        <div id="clockTitle">
-            <p class="labelTitle">
-                时钟<br>clock
-                <div class="circle"></div>
-            </p>    
-        </div>
-        <div id="setter">
-            <form id="couterForm">
-                <input type="number" id="clockH" min="0" max="24" value=0>
-                <input type="number" id="clockM" min="0" max="59" value=0>
-                <input type="number" id="clockS" min="0" max="59" value=0><br>
-                <button type="button" onclick="resetTime()" name="reset" class="buttonCss1">重置</button>
-                <button type="button" onclick="confirmClock()" id="confirmC" class="buttonCss">确认</button>
-            </form>
+            </div>
+            <div id="digital">00:00:00</div>
+            <!-- 闹钟 -->
+            <div id="alarmTitle">
+                <p class="labelTitle">
+                    闹钟<br>alarm
+                    <div class="circle"></div>
+                </p>    
+            </div>
+            <div id="alarm">
+                <form id="alarmForm">
+                    <input type="time" id="alarmTime" value="12:12">
+                    <div class="alarmbuttonCss">
+                        <input type="radio" name="alarm" value="on" onchange="alarmon()" id="alarmonCss">
+                        <label for="alarmonCss" class="onCss">
+                            <p>ON</p>
+                        </label>
+                        <input type="radio" name="alarm" value="off" onchange="alarmoff()" checked="true" id="alarmoffCss">
+                        <label for="alarmoffCss" class="offCss">
+                            <p>OFF</p>
+                        </label>
+                    </div>
+                </form>
+            </div>
+            <!-- 秒表 -->
+            <div id="stopwatchTitle">
+                <p class="labelTitle">
+                    秒表<br>stopwatch
+                    <div class="circle"></div>
+                </p>    
+            </div>
+            <div id="se">
+                <form id="seForm">
+                    <div id="stopwatchtimeCss">
+                        <div id="seDigital">00:00.00</div>
+                    </div>              
+                    <button type="button" onclick="resetSe()" name="reset" class="buttonCss1">重置</button>
+                    <button type="button" onclick="started()" id="start" class="buttonCss">开始</button>
+                    <button type="button" onclick="paused()" id="pause" style="display: none;" class="buttonCss">暂停</button>
+                </form>
+            </div>
+            <!-- 计时器 -->
+            <div id="timerTitle">
+                <p class="labelTitle">
+                    计时器<br>timer
+                    <div class="circle"></div>
+                </p>    
+            </div>
+            <div id="counter">
+                <form id="couterForm">
+                    <div id="counterIn">
+                        <input type="number" id="counterH" min="0" max="23" value="0">
+                        <input type="number" id="counterM" min="0" max="59" value="0">
+                        <input type="number" id="counterS" min="0" max="59" value="0">
+                    </div>
+                    <div id="counterOut" style="display: none;">
+                        00:00:00
+                    </div>
+                    <br>
+                    <button type="button" onclick="resetCounter()" name="reset" class="buttonCss1">重置</button>
+                    <button type="button" onclick="startedCounter()" id="startC" class="buttonCss">开始</button>
+                    <button type="button" onclick="pausedCounter()" id="pauseC" style="display: none;" class="buttonCss2">暂停</button>
+                </form>
+            </div>
+            <!-- 参数调整时间 -->
+            <div id="clockTitle">
+                <p class="labelTitle">
+                    时钟<br>clock
+                    <div class="circle"></div>
+                </p>    
+            </div>
+            <div id="setter">
+                <form id="couterForm">
+                    <input type="number" id="clockH" min="0" max="24" value=0>
+                    <input type="number" id="clockM" min="0" max="59" value=0>
+                    <input type="number" id="clockS" min="0" max="59" value=0><br>
+                    <button type="button" onclick="resetTime()" name="reset" class="buttonCss1">重置</button>
+                    <button type="button" onclick="confirmClock()" id="confirmC" class="buttonCss">确认</button>
+                </form>
+            </div>
         </div>
     </div>
     <script src="script.js"></script>

--- a/style.css
+++ b/style.css
@@ -7,11 +7,33 @@
 }
 
 #canvas {
-    margin: auto;
+    display: block;
+    margin-right: 100px;
+    margin-left: none;
     float: none;
-    width: var(--width);
+    width: 900px;
     height: var(--height);
     text-align: center;
+    overflow: visible;
+}
+
+#face {
+    display: flex;
+    width: 1800px;
+}
+
+#face #svgclock {
+    width: 900px;
+    height: var(--height);
+    display: block;
+    margin-right: 100px;
+}
+
+#clockfunction {
+    display: block;
+    width: 620px;
+    height: 720px;
+    position: relative;
 }
 
 /*功能实现模块背景css*/
@@ -22,8 +44,8 @@
     border-color: gray;
     width: 600px;
     height: 700px;
-    right: 167px;
-    top: 30px;
+    right: 7px;
+    /*top: 30px;*/
     background-color: navajowhite;
     border-radius: 12px;
     box-shadow: 4px 4px 6px rgba(0, 0, 0, 0.3);
@@ -37,8 +59,8 @@
     border: 10px;
     width: 500px;
     height: 200px;
-    top: 75px;
-    right: 220px;
+    top: 45px;
+    right: 60px;
     background-color: antiquewhite;
     border-radius: 12px;
     box-shadow: 4px 4px 6px rgba(0, 0, 0, 0.3);
@@ -97,8 +119,8 @@
 #digital {
     margin: auto;
     position: absolute;
-    top: 100px;
-    right: 275px;
+    top: 70px;
+    right: 115px;
     float: none;
     font-family: 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;
     font-size: 90px;
@@ -115,7 +137,7 @@
     margin: auto;
     float: none;
     top: 360px;
-    right: 500px;
+    right: 340px;
     width: 220px;
     height: 100px;
     border: 10px;
@@ -130,7 +152,7 @@
     width: 140px;
     height: 50px;
     top: 300px;
-    right: 540px;
+    right: 380px;
     border: 10px;
     border-radius: 12px;
     background-color: antiquewhite;
@@ -238,7 +260,7 @@ input[type="radio"] {
     margin: auto;
     float: none;
     top: 360px;
-    right: 220px;
+    right: 60px;
     width: 220px;
     height: 100px;
     border: 10px;
@@ -253,7 +275,7 @@ input[type="radio"] {
     width: 160px;
     height: 50px;
     top: 300px;
-    right: 249px;
+    right: 89px;
     border: 10px;
     border-radius: 12px;
     background-color: antiquewhite;
@@ -353,7 +375,7 @@ input[type="radio"] {
     margin: auto;
     float: none;
     top: 550px;
-    right: 500px;
+    right: 340px;
     width: 220px;
     height: 100px;
     border: 10px;
@@ -368,7 +390,7 @@ input[type="radio"] {
     width: 140px;
     height: 50px;
     top: 488px;
-    right: 540px;
+    right: 380px;
     border: 10px;
     border-radius: 12px;
     background-color: antiquewhite;
@@ -542,7 +564,7 @@ input[type="radio"] {
     margin: auto;
     float: none;
     top: 550px;
-    right: 220px;
+    right: 60px;
     width: 220px;
     height: 100px;
     border: 10px;
@@ -557,7 +579,7 @@ input[type="radio"] {
     width: 140px;
     height: 50px;
     top: 488px;
-    right: 258px;
+    right: 98px;
     border: 10px;
     border-radius: 12px;
     background-color: antiquewhite;


### PR DESCRIPTION
补丁：将钟表和右侧的计时器组件装入flex容器中而非基于原页面的绝对定位。
原先基于原页面的绝对定位会让页面在缩放的时候显得很奇怪（钟和计时器在不同的缩放下有不同的相对位置，甚至还会重叠）。